### PR TITLE
Added support for CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ complex setup. Yet, it supports many advanced features and dynamic mocks for alm
 - Customize headers and status code if needed, automatically detect content-type if not specified
 - Add custom middlewares to modify requests/responses
 - Mock only specific requests and proxy the rest to an existing server
+- Supports CORS (cross-origin resource-sharing)
 
 ## Installation
 
@@ -52,23 +53,24 @@ CLI usage is quite straightforward you can just run `smoke` unless you want to a
 Usage: smoke [<mocks_folder>] [options]
 
 Base options:
-  -p, --port <num>        Server port           [default: 3000]
-  -h, --host <host>       Server host           [default: "localhost"]
-  -s, --set <name>        Mocks set to use      [default: none]
-  -n, --not-found <glob>  Mocks for 404 errors  [default: "404.*"]
-  -i, --ignore <glob>     Files to ignore       [default: none]
-  -k, --hooks <file>      Middleware hooks      [default: none]
-  -x, --proxy <host>      Fallback proxy if no mock found
-  -l, --logs              Enable server logs
-  -v, --version           Show version
-  --help                  Show help
+  -p, --port <num>                  Server port           [default: 3000]
+  -h, --host <host>                 Server host           [default: "localhost"]
+  -s, --set <name>                  Mocks set to use      [default: none]
+  -n, --not-found <glob>            Mocks for 404 errors  [default: "404.*"]
+  -i, --ignore <glob>               Files to ignore       [default: none]
+  -k, --hooks <file>                Middleware hooks      [default: none]
+  -x, --proxy <host>                Fallback proxy if no mock found
+  -o, --allow-cors [all|<hosts>]    Enable CORS requests  [default: none]
+  -l, --logs                        Enable server logs
+  -v, --version                     Show version
+  --help                            Show help
 
 Mock recording:
-  -r, --record <host>     Proxy & record requests if no mock found
-  -c, --collection <file> Save to single file mock collection
-  -d, --depth <N>         Folder depth for mocks  [default: 1]
-  -a, --save-headers      Save response headers
-  -q, --save-query        Save query parameters
+  -r, --record <host>               Proxy & record requests if no mock found
+  -c, --collection <file>           Save to single file mock collection
+  -d, --depth <N>                   Folder depth for mocks  [default: 1]
+  -a, --save-headers                Save response headers
+  -q, --save-query                  Save query parameters
 ```
 
 ### File naming
@@ -300,6 +302,16 @@ Remember that once you have used `.send()`, `.sendStatus` or `.json()` in a midd
 anymore, that's why you should use the `res.body` property instead if you plan to alter the response later on.
 
 See some [example hooks](test/hooks.js).
+
+## Enabling CORS
+
+Smoke offers support to requests originating from a different origin. However, by default, this would be disabled.
+
+To enable CORS, pass the hosts that you want to allow to `-o` or `--allow-cors` arguments.
+
+**Accepted Values**
+- `all` - Allow requests from `*`
+- `<hosts>` - You could also pass a comma-separated list of hosts that you want to allow requests from something like `'http://localhost:3000,http://example.com'`
 
 ### Single file mock collection
 

--- a/lib/smoke.js
+++ b/lib/smoke.js
@@ -3,6 +3,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const multer = require('multer');
 const proxy = require('express-http-proxy');
+const corsMiddleWare = require('cors');
 
 const {getMocks} = require('./mock');
 const {respondMock} = require('./response');
@@ -18,6 +19,27 @@ function createServer(options) {
     .use(bodyParser.urlencoded({extended: true}))
     .use(bodyParser.json())
     .use(multer().any());
+
+  let allowedOrigins = options.cors ? options.cors.split(',') : [];
+  allowedOrigins = allowedOrigins.map(val => val.trim());
+  if (allowedOrigins.length === 0 || allowedOrigins.includes('all')) {
+    app.use(corsMiddleWare());
+  } else {
+    app.use(corsMiddleWare({ origin: function (origin, callback) {
+        /**
+         * Allow requests with no 'origin'
+         * i.e. mobile apps, curl etc.
+         */
+        if (!origin) return callback(null, true);
+
+        if (allowedOrigins.indexOf(origin) === -1) {
+          const msg = `The CORS policy for this mock does not allow access from the specified origin: ${origin}. For details on how to whitelist requests from this origin, refer to --help.`;
+          return callback(new Error(msg), false);
+        }
+      
+        return callback(null, true);
+    }}));
+  }
 
   let hooks = {before: [], after: []};
 
@@ -65,7 +87,8 @@ function getOptions(options) {
     collection: options.collection || null,
     depth: typeof options.depth === 'number' ? options.depth : 1,
     saveHeaders: options.saveHeaders || false,
-    saveQueryParams: options.saveQueryParams || false
+    saveQueryParams: options.saveQueryParams || false,
+    cors: options.cors || null
   };
 }
 

--- a/lib/smoke.js
+++ b/lib/smoke.js
@@ -21,24 +21,28 @@ function createServer(options) {
     .use(multer().any());
 
   let allowedOrigins = options.cors ? options.cors.split(',') : [];
-  allowedOrigins = allowedOrigins.map(val => val.trim());
+  allowedOrigins = allowedOrigins.map((val) => val.trim());
   if (allowedOrigins.length === 0 || allowedOrigins.includes('all')) {
     app.use(corsMiddleWare());
   } else {
-    app.use(corsMiddleWare({ origin: function (origin, callback) {
-        /**
-         * Allow requests with no 'origin'
-         * i.e. mobile apps, curl etc.
-         */
-        if (!origin) return callback(null, true);
+    app.use(
+      corsMiddleWare({
+        origin: (origin, callback) => {
+          /**
+           * Allow requests with no 'origin'
+           * i.e. mobile apps, curl etc.
+           */
+          if (!origin) return callback(null, true);
 
-        if (allowedOrigins.indexOf(origin) === -1) {
-          const msg = `The CORS policy for this mock does not allow access from the specified origin: ${origin}. For details on how to whitelist requests from this origin, refer to --help.`;
-          return callback(new Error(msg), false);
+          if (!allowedOrigins.includes(origin)) {
+            const msg = `The CORS policy for this mock does not allow access from the specified origin: ${origin}. For details on how to whitelist requests from this origin, refer to --help.`;
+            return callback(new Error(msg), false);
+          }
+
+          return callback(null, true);
         }
-      
-        return callback(null, true);
-    }}));
+      })
+    );
   }
 
   let hooks = {before: [], after: []};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,6 +2736,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "cors": "2.8.5",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.0",
     "fs-extra": "^9.0.1",

--- a/smoke-cli.js
+++ b/smoke-cli.js
@@ -5,29 +5,30 @@ const {createServer, startServer} = require('./lib/smoke');
 const help = `Usage: smoke [<mocks_folder>] [options]
 
 Base options:
-  -p, --port <num>        Server port           [default: 3000]
-  -h, --host <host>       Server host           [default: "localhost"]
-  -s, --set <name>        Mocks set to use      [default: none]
-  -n, --not-found <glob>  Mocks for 404 errors  [default: "404.*"]
-  -i, --ignore <glob>     Files to ignore       [default: none]
-  -k, --hooks <file>      Middleware hooks      [default: none]
-  -x, --proxy <host>      Fallback proxy if no mock found
-  -l, --logs              Enable server logs
-  -v, --version           Show version
-  --help                  Show help
+  -p, --port <num>                  Server port           [default: 3000]
+  -h, --host <host>                 Server host           [default: "localhost"]
+  -s, --set <name>                  Mocks set to use      [default: none]
+  -n, --not-found <glob>            Mocks for 404 errors  [default: "404.*"]
+  -i, --ignore <glob>               Files to ignore       [default: none]
+  -k, --hooks <file>                Middleware hooks      [default: none]
+  -x, --proxy <host>                Fallback proxy if no mock found
+  -o, --allow-cors [all|<hosts>]    Enable CORS requests  [default: none]
+  -l, --logs                        Enable server logs
+  -v, --version                     Show version
+  --help                            Show help
 
 Mock recording:
-  -r, --record <host>     Proxy & record requests if no mock found
-  -c, --collection <file> Save to single file mock collection
-  -d, --depth <N>         Folder depth for mocks  [default: 1]
-  -a, --save-headers      Save response headers
-  -q, --save-query        Save query parameters
+  -r, --record <host>               Proxy & record requests if no mock found
+  -c, --collection <file>           Save to single file mock collection
+  -d, --depth <N>                   Folder depth for mocks  [default: 1]
+  -a, --save-headers                Save response headers
+  -q, --save-query                  Save query parameters
 `;
 
 function run(args) {
   const options = minimist(args, {
     number: ['port', 'depth'],
-    string: ['host', 'set', 'not-found', 'record', 'ignore', 'hooks', 'proxy', 'collection'],
+    string: ['host', 'set', 'not-found', 'record', 'ignore', 'hooks', 'proxy', 'collection', 'allow-cors'],
     boolean: ['help', 'version', 'logs', 'save-headers', 'save-query'],
     alias: {
       p: 'port',
@@ -42,7 +43,8 @@ function run(args) {
       q: 'save-query',
       i: 'ignore',
       k: 'hooks',
-      x: 'proxy'
+      x: 'proxy',
+      o: 'allow-cors'
     }
   });
 
@@ -69,7 +71,8 @@ function run(args) {
     collection: options.collection,
     depth: options.depth,
     saveHeaders: options['save-headers'],
-    saveQueryParams: options['save-query']
+    saveQueryParams: options['save-query'],
+    cors: options['allow-cors']
   });
 
   if (app) {


### PR DESCRIPTION
Hi @sinedied,

Firstly, kudos on coming up with a wonderful API mocking tool. It really helps me with quicker development sprints in situations where integration testing would not immediately be possible for me.

So, I had a requirement where I wanted to mock an API which would be consumed by a front-end (both running on different origins) and hence I needed support for CORS. After doing so myself, I thought that it could be great if we could offer this out-of-the-box with `smoke` and hence this PR.

Please do get back to me with your thoughts on this.